### PR TITLE
Wall cleanup

### DIFF
--- a/src/map.c
+++ b/src/map.c
@@ -302,7 +302,6 @@ void map_addwall(struct Map *map, int x, int z, enum WallDirection dir)
 	w->startx = x;
 	w->startz = z;
 	w->dir = dir;
-	wall_init(w);
 }
 
 void map_movecontent(struct Map *map, int dx, int dz)
@@ -310,7 +309,6 @@ void map_movecontent(struct Map *map, int dx, int dz)
 	for (int i = 0; i < map->nwalls; i++) {
 		map->walls[i].startx += dx;
 		map->walls[i].startz += dz;
-		wall_init(&map->walls[i]);
 	}
 	for (int i = 0; i < 2; i++) {
 		map->playerlocs[i].x += dx;

--- a/src/mapeditor.c
+++ b/src/mapeditor.c
@@ -170,7 +170,6 @@ static void keep_wall_within_map(const struct MapEditor *ed, struct Wall *w, boo
 
 	clamp(&w->startx, xmin, xmax);
 	clamp(&w->startz, zmin, zmax);
-	wall_init(w);
 }
 
 static bool mouse_is_on_ellipsoid(const struct Camera *cam, const struct Ellipsoid *el, int x, int y)
@@ -246,7 +245,6 @@ static bool mouse_location_to_wall(const struct MapEditor *ed, struct Wall *dst,
 	};
 
 	for (int i = 0; i < sizeof(couldbe)/sizeof(couldbe[0]); i++) {
-		wall_init(&couldbe[i]);
 		if (mouse_is_on_wall(&ed->cam, &couldbe[i], mousex, mousey)) {
 			*dst = couldbe[i];
 			return true;
@@ -309,7 +307,6 @@ static void do_resize(struct MapEditor *ed, int x, int z)
 	ed->sel.data.resize.mainwall.startz = z;
 
 	keep_wall_within_map(ed, &ed->sel.data.resize.mainwall, true);
-	wall_init(&ed->sel.data.resize.mainwall);
 	for (struct Wall *const *w = ed->sel.data.resize.walls; w < &ed->sel.data.resize.walls[ed->sel.data.resize.nwalls]; w++)
 	{
 		switch(ed->sel.data.resize.mainwall.dir) {
@@ -320,7 +317,6 @@ static void do_resize(struct MapEditor *ed, int x, int z)
 			(*w)->startx = ed->sel.data.resize.mainwall.startx;
 			break;
 		}
-		wall_init(*w);
 	}
 }
 
@@ -364,7 +360,6 @@ static void set_location_of_moving_wall(struct MapEditor *ed, struct Wall w)
 	if (!find_wall_from_map(&w, ed->map)) {
 		// Not going on top of another wall, can move
 		*ed->sel.data.mvwall = w;
-		wall_init(ed->sel.data.mvwall);
 		map_save(ed->map);
 	}
 }
@@ -767,7 +762,6 @@ static void show_editor(struct MapEditor *ed)
 
 	show_all(ed->map->walls, ed->map->nwalls, highlight, els, nels, &ed->cam);
 	if (borderwall) {
-		wall_init(borderwall);
 		struct Rect3 r = wall_to_rect(borderwall);
 		rect3_drawborder(&r, &ed->cam);
 	}

--- a/src/mapeditor.c
+++ b/src/mapeditor.c
@@ -188,7 +188,7 @@ static bool mouse_is_on_wall(const struct Camera *cam, const struct Wall *w, int
 {
 	int xmin, xmax;
 	struct Rect3Cache rcache;
-	struct Rect3 r = wall_to_rect(w);
+	struct Rect3 r = wall_to_rect3(w);
 	return rect3_visible_fillcache(&r, cam, &rcache)
 		&& rect3_xminmax(&rcache, y, &xmin, &xmax)
 		&& xmin <= x && x <= xmax;
@@ -762,7 +762,7 @@ static void show_editor(struct MapEditor *ed)
 
 	show_all(ed->map->walls, ed->map->nwalls, highlight, els, nels, &ed->cam);
 	if (borderwall) {
-		struct Rect3 r = wall_to_rect(borderwall);
+		struct Rect3 r = wall_to_rect3(borderwall);
 		rect3_drawborder(&r, &ed->cam);
 	}
 }

--- a/src/showall.c
+++ b/src/showall.c
@@ -73,7 +73,7 @@ static void add_ellipsoid_if_visible(struct ShowingState *st, int idx)
 
 static void add_wall_if_visible(struct ShowingState *st, int idx)
 {
-	struct Rect3 r = wall_to_rect(&st->walls[idx]);
+	struct Rect3 r = wall_to_rect3(&st->walls[idx]);
 	struct Rect3Cache rcache;
 	if (rect3_visible_fillcache(&r, st->cam, &rcache)) {
 		ID id = ID_NEW(ID_TYPE_WALL, idx);

--- a/src/wall.c
+++ b/src/wall.c
@@ -33,20 +33,6 @@ void wall_init(struct Wall *w)
 			}
 		}
 	}
-
-	w->top1 = w->top2 = (Vec3){ (float)w->startx, Y_MAX, (float)w->startz };
-	w->bot1 = w->bot2 = (Vec3){ (float)w->startx, Y_MIN, (float)w->startz };
-
-	switch(w->dir) {
-		case WALL_DIR_XY:
-			w->top2.x += 1.0f;
-			w->bot2.x += 1.0f;
-			break;
-		case WALL_DIR_ZY:
-			w->top2.z += 1.0f;
-			w->bot2.z += 1.0f;
-			break;
-	}
 }
 
 struct Rect3 wall_to_rect(const struct Wall *w)

--- a/src/wall.c
+++ b/src/wall.c
@@ -8,7 +8,7 @@
 #define Y_MAX 1.0f
 
 
-struct Rect3 wall_to_rect(const struct Wall *w)
+struct Rect3 wall_to_rect3(const struct Wall *w)
 {
 	int dx = (w->dir == WALL_DIR_XY);
 	int dz = (w->dir == WALL_DIR_ZY);

--- a/src/wall.c
+++ b/src/wall.c
@@ -8,33 +8,6 @@
 #define Y_MAX 1.0f
 
 
-static float linear_map(float srcmin, float srcmax, float dstmin, float dstmax, float val)
-{
-	float ratio = (val - srcmin)/(srcmax - srcmin);
-	return dstmin + ratio*(dstmax - dstmin);
-}
-
-void wall_init(struct Wall *w)
-{
-	for (int xznum = 0; xznum < WALL_CP_COUNT; xznum++) {
-		for (int ynum = 0; ynum < WALL_CP_COUNT; ynum++) {
-			Vec3 *ptr = &w->collpoints[xznum][ynum];
-			ptr->x = (float)w->startx;
-			ptr->y = linear_map(0, WALL_CP_COUNT-1, Y_MIN, Y_MAX, (float)ynum);
-			ptr->z = (float)w->startz;
-
-			switch(w->dir) {
-			case WALL_DIR_XY:
-				ptr->x += linear_map(0, WALL_CP_COUNT-1, 0, 1, (float)xznum);
-				break;
-			case WALL_DIR_ZY:
-				ptr->z += linear_map(0, WALL_CP_COUNT-1, 0, 1, (float)xznum);
-				break;
-			}
-		}
-	}
-}
-
 struct Rect3 wall_to_rect(const struct Wall *w)
 {
 	int dx = (w->dir == WALL_DIR_XY);
@@ -54,6 +27,19 @@ bool wall_match(const struct Wall *w1, const struct Wall *w2)
 	return w1->dir == w2->dir && w1->startx == w2->startx && w1->startz == w2->startz;
 }
 
+
+/*
+I thought about doing collision checking by dividing it into these cases:
+- The ellipsoid could touch the corner points of the wall.
+- The ellipsoid could touch any edge of the wall so that it touches between the corners,
+  and doesn't touch the corners.
+- The ellipsoid could touch the "center part" of the wall without touching any edges or
+  corners.
+
+Handling all this would be a lot of code, so instead we just spread some points
+uniformly across the wall and see if those touch. I call these collision points.
+*/
+#define COLLISION_POINT_COUNT 10
 
 void wall_bumps_ellipsoid(const struct Wall *w, struct Ellipsoid *el)
 {
@@ -81,10 +67,17 @@ void wall_bumps_ellipsoid(const struct Wall *w, struct Ellipsoid *el)
 	// Switch to coordinates where the ellipsoid is a ball with radius 1
 	Vec3 elcenter = mat3_mul_vec3(el->world2uball, el->center);
 
-	for (int xznum = 0; xznum < WALL_CP_COUNT; xznum++) {
-		for (int ynum = 0; ynum < WALL_CP_COUNT; ynum++) {
-			Vec3 collpoint = mat3_mul_vec3(el->world2uball, w->collpoints[xznum][ynum]);
-			Vec3 diff = vec3_sub(elcenter, collpoint);
+	float c = 1.0f/(COLLISION_POINT_COUNT - 1);
+
+	for (int xznum = 0; xznum < COLLISION_POINT_COUNT; xznum++) {
+		for (int ynum = 0; ynum < COLLISION_POINT_COUNT; ynum++) {
+			Vec3 collpoint = { w->startx, Y_MIN+(Y_MAX-Y_MIN)*c*ynum, w->startz };
+			switch(w->dir) {
+				case WALL_DIR_XY: collpoint.x += xznum*c; break;
+				case WALL_DIR_ZY: collpoint.z += xznum*c; break;
+			}
+
+			Vec3 diff = vec3_sub(elcenter, mat3_mul_vec3(el->world2uball, collpoint));
 
 			float distSQUARED = vec3_lengthSQUARED(diff);
 			if (distSQUARED >= 1)   // doesn't bump
@@ -97,7 +90,7 @@ void wall_bumps_ellipsoid(const struct Wall *w, struct Ellipsoid *el)
 			vec3_apply_matrix(&diff, el->uball2world);
 
 			// if we're not bumping on the edge of the wall
-			if (xznum != 0 && xznum != WALL_CP_COUNT - 1) {
+			if (xznum != 0 && xznum != COLLISION_POINT_COUNT - 1) {
 				// then we should move only in direction opposite to wall
 				switch(w->dir) {
 					case WALL_DIR_XY: diff.x = 0; break;

--- a/src/wall.h
+++ b/src/wall.h
@@ -12,31 +12,14 @@ x or z direction from there, as specified by this.
 */
 enum WallDirection { WALL_DIR_XY, WALL_DIR_ZY };
 
-/*
-I thought about doing collision checking by dividing it into these cases:
-- The ellipsoid could touch the corner points of the wall.
-- The ellipsoid could touch any edge of the wall so that it touches between the corners,
-  and doesn't touch the corners.
-- The ellipsoid could touch the "center part" of the wall without touching any edges or
-  corners.
-
-Handling all this would be a lot of code, so instead we just spread some points
-uniformly across the wall and see if those touch. I call these collision points.
-*/
-#define WALL_CP_COUNT 10
-
 struct Wall {
 	int startx;
 	int startz;
 	enum WallDirection dir;
-
-	// don't use outside wall.c
-	Vec3 collpoints[WALL_CP_COUNT][WALL_CP_COUNT];
 };
 
-// Call this after setting startx,startz,dir of a new wall
 // Can be called multiple times
-void wall_init(struct Wall *w);
+void wall_init_collpoints(struct Wall *w);
 
 struct Rect3 wall_to_rect(const struct Wall *w);
 

--- a/src/wall.h
+++ b/src/wall.h
@@ -18,9 +18,6 @@ struct Wall {
 	enum WallDirection dir;
 };
 
-// Can be called multiple times
-void wall_init_collpoints(struct Wall *w);
-
 struct Rect3 wall_to_rect(const struct Wall *w);
 
 // does not require using wall_init()

--- a/src/wall.h
+++ b/src/wall.h
@@ -18,7 +18,7 @@ struct Wall {
 	enum WallDirection dir;
 };
 
-struct Rect3 wall_to_rect(const struct Wall *w);
+struct Rect3 wall_to_rect3(const struct Wall *w);
 
 // does not require using wall_init()
 bool wall_match(const struct Wall *w1, const struct Wall *w2);

--- a/src/wall.h
+++ b/src/wall.h
@@ -30,29 +30,6 @@ struct Wall {
 	int startz;
 	enum WallDirection dir;
 
-	/* corners in world coordinates, always up to date because walls don't move.
-
-	now some 3D ascii art (imagine top1 and bot1 being closer to you)
-
-	       /top2
-	      / |
-	     /  |
-	    /   |
-	   /    |
-	 top1   |
-	  |     bot2
-	  |    /
-	  |   /
-	  |  /
-	  | /
-	 bot1
-
-	top1 and bot1 aren't always closer to camera than top2 and bot2. The important
-	thing is that top1 and bot1 are always vertically lined up, and so are top2
-	and bot2.
-	*/
-	Vec3 top1, top2, bot1, bot2;
-
 	// don't use outside wall.c
 	Vec3 collpoints[WALL_CP_COUNT][WALL_CP_COUNT];
 };


### PR DESCRIPTION
Get rid of `wall_init()`. It complicated other code, and collision checking will probably be fast enough without it.

Rename `wall_to_rect` to `wall_to_rect3`, for clarity.