### PR TITLE
map editor: swap ellipsoid edits correspondingly to locations when deleting enemies

### DIFF
--- a/src/mapeditor.c
+++ b/src/mapeditor.c
@@ -518,6 +518,13 @@ static void on_arrow_key(struct MapEditor *ed, float angle, bool oppositespresse
 	}
 }
 
+static void swap(struct EllipsoidEdit *a, struct EllipsoidEdit *b)
+{
+	struct EllipsoidEdit tmp = *a;
+	*a = *b;
+	*b = tmp;
+}
+
 static void delete_selected(struct MapEditor *ed)
 {
 	log_printf("Trying to delete selected item");
@@ -529,6 +536,7 @@ static void delete_selected(struct MapEditor *ed)
 					&& ed->map->enemylocs[i].z == ed->sel.data.square.z)
 				{
 					ed->map->enemylocs[i] = ed->map->enemylocs[--ed->map->nenemylocs];
+					swap(&ed->enemyedits[i], &ed->enemyedits[ed->map->nenemylocs]);
 					log_printf("Deleted an enemy spawning location");
 					map_save(ed->map);
 					return;


### PR DESCRIPTION
fixes #75